### PR TITLE
:green_heart: Remove library name from ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,4 @@ on:
 jobs:
   ci:
     uses: libhal/ci/.github/workflows/library.yml@main
-    with:
-      library: libhal-__target__
     secrets: inherit

--- a/.github/workflows/update_name.yml
+++ b/.github/workflows/update_name.yml
@@ -23,7 +23,7 @@ jobs:
         run: echo ${{ github.event.repository.name }} | sed -En "s/libhal-(.*)/target_name=\1/p" >> $GITHUB_ENV
 
       - name: Replace placeholder's in files
-        run: find . -type f -not -path '*/\.git/*' -type f -print0 | xargs -0 sed -i "s/__target__/${{ env.target_name }}/g"
+        run: find . -type f -not -path '*/\.git/*' -exec sed -i "s/__target__/${{ env.target_name }}/g" {} +
 
       - name: Replace placeholder's in directory names
         run: find . -type d -not -path '*/\.git/*' | xargs -r rename "s/__target__/${{ env.target_name }}/g"


### PR DESCRIPTION
Committing & pushing changes to workflow files requires additional permissions in github actions. The action can either get elevated permissions for this task, or the library name can be removed from the workflow dispatch. Removing the library name means that the package name and the repo name must match. I personally believe that is an acceptable constraint. If this needs to be changed, then the library name can be coded directly.