### PR TITLE
:construction_worker: Remove "release" job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,9 @@ name: ✅ Checks
 on:
   workflow_dispatch:
   pull_request:
+  release:
+    types: [published]
   push:
-    tags:
-      - "*"
     branches:
       - main
   schedule:
@@ -45,18 +45,3 @@ jobs:
       # Replace with appropriate processor profile
       processor_profile: https://github.com/libhal/libhal-armcortex.git
     secrets: inherit
-
-  # Add more `profile` blocks below for each supported platform profile
-
-  release:
-    # All jobs above MUST pass before creating a release
-    # Add more jobs to the `needs` section as they are added
-    needs: [ci, profile1, profile2]
-    if: startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Release
-        uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/')
-        with:
-          generate_release_notes: true


### PR DESCRIPTION
Releases trigger package uploads, so creating a release is redundant.