### PR TITLE
:construction_worker: Use ci/4.x.y version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,9 @@ on:
   workflow_dispatch:
   pull_request:
   release:
-    types: [published]
+    types:
+      - published
+      - deleted
   push:
     branches:
       - main
@@ -27,11 +29,11 @@ on:
 
 jobs:
   ci:
-    uses: libhal/ci/.github/workflows/library.yml@4.1.0
+    uses: libhal/ci/.github/workflows/library.yml@4.x.y
     secrets: inherit
 
   profile1:
-    uses: libhal/ci/.github/workflows/platform_deploy.yml@4.1.0
+    uses: libhal/ci/.github/workflows/platform_deploy.yml@4.x.y
     with:
       profile: profile1
       # Replace with appropriate processor profile
@@ -39,7 +41,7 @@ jobs:
     secrets: inherit
 
   profile2:
-    uses: libhal/ci/.github/workflows/platform_deploy.yml@4.1.0
+    uses: libhal/ci/.github/workflows/platform_deploy.yml@4.x.y
     with:
       profile: profile2
       # Replace with appropriate processor profile

--- a/conanfile.py
+++ b/conanfile.py
@@ -77,14 +77,14 @@ class libhal___platform___conan(ConanFile):
 
     def build_requirements(self):
         self.tool_requires("libhal-cmake-util/1.0.0")
-        self.test_requires("libhal-mock/[^2.0.0]")
+        self.test_requires("libhal-mock/[^2.0.1]")
         self.test_requires("boost-ext-ut/1.1.9")
 
     def requirements(self):
         self.requires("libhal/[^2.0.0]")
-        self.requires("libhal-util/[^2.0.0]")
+        self.requires("libhal-util/[^3.0.0]")
         # Replace with appropriate processor library
-        self.requires("libhal-armcortex/[^2.0.0]")
+        self.requires("libhal-armcortex/[^2.0.3]")
 
     def layout(self):
         cmake_layout(self)


### PR DESCRIPTION
The 4.x.y branch scheme means that this repo will get the latest changes to the ci that does not include breaking changes.